### PR TITLE
make aType FRAME_TARGET controllable

### DIFF
--- a/sanitizer.js
+++ b/sanitizer.js
@@ -952,6 +952,7 @@ var html = (function(html4) {
                     case html4.atype['GLOBAL_NAME']:
                     case html4.atype['LOCAL_NAME']:
                     case html4.atype['CLASSES']:
+                    case html4.atype['FRAME_TARGET']:
                         value = opt_nmTokenPolicy ? opt_nmTokenPolicy(value) : value;
                         if (opt_logger) {
                             log(opt_logger, tagName, attribName, oldValue, value);


### PR DESCRIPTION
Problem: The target attribute on <a> tag are per default removed. The value is set to null.
